### PR TITLE
Fixes text styling in Firefox

### DIFF
--- a/public/js/components/home.js
+++ b/public/js/components/home.js
@@ -48,8 +48,8 @@ var defaultIndexContent = `<!DOCTYPE html>
       .text("Edit the code below to change me!")
       .attr("y", 200)
       .attr("x", 120)
-      .style("font-size", 36)
-      .style("font-family", "monospace")
+      .attr("font-size", 36)
+      .attr("font-family", "monospace")
 
   </script>
 </body>


### PR DESCRIPTION
Text styling used to be done by svg.style, which works fine in Google Chrome, but has no effect in Firefox. Using svg.attr seems to work fine on both. Fix for #204